### PR TITLE
Update Ruby-Zip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.4 (2020-04-08)
+
+- Replace -rubygems with -rrubygems
+
 # 1.0.3 (2018-01-26)
 
 - Bugfix: Workaround a possible crash in safe_yaml (#237)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# 1.0.4 (2020-04-08)
+# 1.0.3.1 (2020-04-08)
 
-- Replace -rubygems with -rrubygems
+- Replace -rubygems with -rrubygems. This change is needed in order to use the library with ruby greater than 2.5
 
 # 1.0.3 (2018-01-26)
 

--- a/lib/twine/version.rb
+++ b/lib/twine/version.rb
@@ -1,3 +1,3 @@
 module Twine
-  VERSION = '1.0.3'
+  VERSION = '1.0.4'
 end

--- a/lib/twine/version.rb
+++ b/lib/twine/version.rb
@@ -1,3 +1,3 @@
 module Twine
-  VERSION = '1.0.4'
+  VERSION = '1.0.3.1'
 end

--- a/twine
+++ b/twine
@@ -1,3 +1,3 @@
 #!/bin/sh
 BASEDIR=$(dirname $0)
-ruby -rubygems -I $BASEDIR/lib $BASEDIR/bin/twine "$@"
+ruby -rrubygems -I $BASEDIR/lib $BASEDIR/bin/twine "$@"

--- a/twine.gemspec
+++ b/twine.gemspec
@@ -1,33 +1,33 @@
-$LOAD_PATH.unshift 'lib'
-require 'twine/version'
+$LOAD_PATH.unshift "lib"
+require "twine/version"
 
 Gem::Specification.new do |s|
-  s.name         = "twine"
-  s.version      = Twine::VERSION
-  s.date         = Time.now.strftime('%Y-%m-%d')
-  s.summary      = "Manage strings and their translations for your iOS, Android and other projects."
-  s.homepage     = "https://github.com/mobiata/twine"
-  s.email        = "twine@mobiata.com"
-  s.authors      = [ "Sebastian Celis" ]
-  s.has_rdoc     = false
-  s.license      = "BSD-3-Clause"
+  s.name = "twine"
+  s.version = Twine::VERSION
+  s.date = Time.now.strftime("%Y-%m-%d")
+  s.summary = "Manage strings and their translations for your iOS, Android and other projects."
+  s.homepage = "https://github.com/mobiata/twine"
+  s.email = "twine@mobiata.com"
+  s.authors = ["Sebastian Celis"]
+  s.has_rdoc = false
+  s.license = "BSD-3-Clause"
 
-  s.files        = %w( Gemfile README.md LICENSE )
-  s.files       += Dir.glob("lib/**/*")
-  s.files       += Dir.glob("bin/**/*")
-  s.files       += Dir.glob("test/**/*")
-  s.test_files   = Dir.glob("test/test_*")
+  s.files = %w( Gemfile README.md LICENSE )
+  s.files += Dir.glob("lib/**/*")
+  s.files += Dir.glob("bin/**/*")
+  s.files += Dir.glob("test/**/*")
+  s.test_files = Dir.glob("test/test_*")
 
   s.required_ruby_version = ">= 2.0"
-  s.add_runtime_dependency('rubyzip', "~> 1.1")
-  s.add_runtime_dependency('safe_yaml', "~> 1.0")
-  s.add_development_dependency('rake', "~> 10.4")
-  s.add_development_dependency('minitest', "~> 5.5")
-  s.add_development_dependency('minitest-ci', "~> 3.0")
-  s.add_development_dependency('mocha', "~> 1.1")
+  s.add_runtime_dependency("rubyzip", "~> 2.0")
+  s.add_runtime_dependency("safe_yaml", "~> 1.0")
+  s.add_development_dependency("rake", "~> 10.4")
+  s.add_development_dependency("minitest", "~> 5.5")
+  s.add_development_dependency("minitest-ci", "~> 3.0")
+  s.add_development_dependency("mocha", "~> 1.1")
 
-  s.executables  = %w( twine )
-  s.description  = <<desc
+  s.executables = %w( twine )
+  s.description = <<desc
   Twine is a command line tool for managing your strings and their translations.
 
   It is geared toward Mac OS X, iOS, and Android developers.


### PR DESCRIPTION
[TSIOS-5586]

Twine being locked to an old version of Ruby-Zip was blocking our Fastlane from updating, and there are API changes in AppStoreConnect which we need to accommodate by updating Fastlane.